### PR TITLE
fix: launch desktop/app via the project venv interpreter

### DIFF
--- a/run.py
+++ b/run.py
@@ -27,13 +27,34 @@ class Runner:
         """Start the MT5 worker."""
         subprocess.run(["python", "src/scripts/start_worker.py"])
 
+    @staticmethod
+    def _resolve_python(root: Path) -> str:
+        """Return the project venv's Python interpreter under `root`, or fall back
+        to the current interpreter.
+
+        The single-process and desktop apps need the venv-installed deps
+        (mitmproxy, pywebview, ...). Resolving the venv interpreter here lets
+        `python run.py desktop` work even when run.py is launched with a bare
+        system Python that lacks those deps.
+        """
+        for candidate in (
+            root / "venv" / "Scripts" / "python.exe",  # Windows venv layout
+            root / "venv" / "bin" / "python",          # POSIX venv layout
+        ):
+            if candidate.exists():
+                return str(candidate)
+        return sys.executable
+
+    def _project_python(self) -> str:
+        return self._resolve_python(Path(__file__).resolve().parent)
+
     def run_app(self):
         """Start the unified single-process engine (no Docker/Redis/Postgres)."""
-        subprocess.run([sys.executable, "-m", "app"])
+        subprocess.run([self._project_python(), "-m", "app"])
 
     def run_desktop(self):
         """Launch the desktop app (window + tray + Start/Stop)."""
-        subprocess.run([sys.executable, "-m", "app.desktop"])
+        subprocess.run([self._project_python(), "-m", "app.desktop"])
 
     def update_requirements(self):
         """Update requirements.txt."""

--- a/tests/unit/test_run_launcher.py
+++ b/tests/unit/test_run_launcher.py
@@ -1,0 +1,29 @@
+"""run.py must launch the single-process/desktop apps with the project's venv
+interpreter (which has the app deps), so `python run.py desktop` works even when
+invoked with a bare system Python that lacks pywebview/mitmproxy/etc.
+"""
+import sys
+from pathlib import Path
+
+from run import Runner
+
+
+def test_resolve_python_prefers_windows_venv(tmp_path):
+    scripts = tmp_path / "venv" / "Scripts"
+    scripts.mkdir(parents=True)
+    py = scripts / "python.exe"
+    py.write_text("")
+    assert Runner._resolve_python(tmp_path) == str(py)
+
+
+def test_resolve_python_prefers_posix_venv(tmp_path):
+    bind = tmp_path / "venv" / "bin"
+    bind.mkdir(parents=True)
+    py = bind / "python"
+    py.write_text("")
+    assert Runner._resolve_python(tmp_path) == str(py)
+
+
+def test_resolve_python_falls_back_to_sys_executable(tmp_path):
+    # No venv under tmp_path -> use the current interpreter.
+    assert Runner._resolve_python(tmp_path) == sys.executable


### PR DESCRIPTION
## Summary

`python run.py desktop` failed with `ModuleNotFoundError: No module named 'webview'` when run.py was launched with a bare system Python — `run_desktop`/`run_app` used `subprocess.run([sys.executable, "-m", ...])`, but the app deps (pywebview, mitmproxy, ...) live in the project venv.

- Add `Runner._resolve_python(root)` which returns the project venv interpreter (`venv/Scripts/python.exe` on Windows, `venv/bin/python` on POSIX), falling back to `sys.executable`.
- `run_app` (`start`) and `run_desktop` (`desktop`) now launch via that interpreter, so `python run.py desktop` works regardless of which Python invoked run.py — no need to type the full `venv\Scripts\python.exe` path.

## Test Plan
- [x] `pytest tests/unit/test_run_launcher.py -q` → 3 passed (Windows venv, POSIX venv, fallback)
- [x] `pytest tests/unit -q` → 70 passed
- [x] `Runner()._project_python()` resolves to the existing venv interpreter on this machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)